### PR TITLE
Fix title handling with special characters

### DIFF
--- a/src/content/injectButton.ts
+++ b/src/content/injectButton.ts
@@ -44,7 +44,16 @@ function createButton() {
 
 function getBibData(): BibData {
   const titleMeta = document.querySelector('meta[name="title"]') as HTMLMetaElement | null;
-  const title = titleMeta?.content || document.title.replace(/ - YouTube$/, '');
+  let title = titleMeta?.content || document.title.replace(/ - YouTube$/, '');
+  try {
+    title = decodeURIComponent(title);
+  } catch {
+    // ignore decoding errors
+  }
+  if (!title) {
+    const titleEl = document.querySelector('h1 yt-formatted-string');
+    title = (titleEl?.textContent || '').trim();
+  }
 
   const channelEl = document.querySelector('ytd-channel-name a');
   const channel = (channelEl?.textContent || '').trim();


### PR DESCRIPTION
## Summary
- make title extraction more robust by decoding URI sequences and falling back to `h1` text

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68526712ce0c8322a97aeb65f4f99dbe